### PR TITLE
Verify featured salon view count implementation and schema

### DIFF
--- a/backend/prisma/migrations/20251106090000_add_salon_view_tracking/migration.sql
+++ b/backend/prisma/migrations/20251106090000_add_salon_view_tracking/migration.sql
@@ -1,0 +1,27 @@
+-- Add view count column for salons and salon view tracking table
+
+-- AlterTable
+ALTER TABLE "Salon" ADD COLUMN IF NOT EXISTS "viewCount" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "SalonView" (
+    "id" TEXT NOT NULL,
+    "salonId" TEXT NOT NULL,
+    "userId" TEXT,
+    "ipAddress" TEXT,
+    "viewedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SalonView_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "SalonView_salonId_idx" ON "SalonView"("salonId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "SalonView_userId_idx" ON "SalonView"("userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "SalonView_viewedAt_idx" ON "SalonView"("viewedAt");
+
+-- AddForeignKey
+ALTER TABLE "SalonView" ADD CONSTRAINT IF NOT EXISTS "SalonView_salonId_fkey" FOREIGN KEY ("salonId") REFERENCES "Salon"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Add database migration for salon view tracking to ensure view count logic functions correctly.

The existing view tracking implementation relied on the `Salon.viewCount` column and `SalonView` table, but these were not present in the database schema, causing runtime failures. This migration creates the necessary database structures.

---
<a href="https://cursor.com/background-agent?bcId=bc-d63d6555-19d9-48f2-a102-a0f8c7b693ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d63d6555-19d9-48f2-a102-a0f8c7b693ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

