### PR TITLE
Resolve database merge conflicts for railway deployment

### DIFF
--- a/backend/prisma/migrations/20251106090000_add_salon_view_tracking/migration.sql
+++ b/backend/prisma/migrations/20251106090000_add_salon_view_tracking/migration.sql
@@ -24,4 +24,13 @@ CREATE INDEX IF NOT EXISTS "SalonView_userId_idx" ON "SalonView"("userId");
 CREATE INDEX IF NOT EXISTS "SalonView_viewedAt_idx" ON "SalonView"("viewedAt");
 
 -- AddForeignKey
-ALTER TABLE "SalonView" ADD CONSTRAINT IF NOT EXISTS "SalonView_salonId_fkey" FOREIGN KEY ("salonId") REFERENCES "Salon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'SalonView_salonId_fkey'
+    ) THEN
+        ALTER TABLE "SalonView" ADD CONSTRAINT "SalonView_salonId_fkey" FOREIGN KEY ("salonId") REFERENCES "Salon"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END$$;


### PR DESCRIPTION
Gate foreign key creation in a SQL migration to prevent deploy-time errors.

This change wraps the `ALTER TABLE ADD CONSTRAINT` statement in a `DO $$` block with an `IF NOT EXISTS` condition. This ensures that Postgres skips the foreign key creation if the constraint already exists, resolving a deploy-time syntax error that occurred during database merges or re-deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-24e2326a-ac4d-49ae-950a-b0197791c5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24e2326a-ac4d-49ae-950a-b0197791c5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

